### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import { StoryDecorator } from 'storybook__react';
+
+interface Options {
+	url: string;
+}
+
+export default function (options: Options): StoryDecorator;
+export function WithFigma(): React.Component<Options,{}>;


### PR DESCRIPTION
I've added typings for TypeScript.

They should be pretty self explanatory, but feel free to ask questions if not.
They've been tested with our own project that uses this addon with TypeScript. Both exports require a url parameter/prop, and don't allow anything else.